### PR TITLE
basic to basic-server-rendering

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: rails s
 hot: sh -c 'cd client && npm start'
 client: sh -c 'rm app/assets/javascripts/generated/* || true && cd client && npm run build:dev:client'
-
+server: sh -c 'cd client && npm run build:dev:server'

--- a/app/views/hello_world/index.html.erb
+++ b/app/views/hello_world/index.html.erb
@@ -1,6 +1,6 @@
-<h1 class="alert alert-info this-works">Client Rendering</h1>
+<h1 class="alert alert-info this-works">Server Rendering</h1>
 <%= react_component("HelloWorldApp",
                      @hello_world_props,
                      generator_function: false,
-                     prerender: false,
+                     prerender: true,
                      trace: true) %>

--- a/client/app/bundles/HelloWorld/startup/HelloWorldAppClient.jsx
+++ b/client/app/bundles/HelloWorld/startup/HelloWorldAppClient.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import HelloWorld from '../containers/HelloWorld';
+
+const HelloWorldAppClient = props => {
+  const reactComponent = (
+    <HelloWorld {...props} />
+  );
+  return reactComponent;
+};
+
+export default HelloWorldAppClient;

--- a/client/app/bundles/HelloWorld/startup/HelloWorldAppServer.jsx
+++ b/client/app/bundles/HelloWorld/startup/HelloWorldAppServer.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import HelloWorld from '../containers/HelloWorld';
 
-const HelloWorldApp = props => {
+const HelloWorldAppServer = props => {
   const reactComponent = (
     <HelloWorld {...props} />
   );
   return reactComponent;
 };
 
-export default HelloWorldApp;
+export default HelloWorldAppServer;

--- a/client/app/bundles/HelloWorld/startup/clientGlobals.jsx
+++ b/client/app/bundles/HelloWorld/startup/clientGlobals.jsx
@@ -1,0 +1,4 @@
+import HelloWorldAppClient from './HelloWorldAppClient';
+
+// This is how react_on_rails can see the HelloWorldApp in the browser.
+window.HelloWorldApp = HelloWorldAppClient;

--- a/client/app/bundles/HelloWorld/startup/globals.jsx
+++ b/client/app/bundles/HelloWorld/startup/globals.jsx
@@ -1,4 +1,0 @@
-import HelloWorldApp from './HelloWorldApp';
-
-// This is how react_on_rails can see the HelloWorldApp in the browser.
-window.HelloWorldApp = HelloWorldApp;

--- a/client/app/bundles/HelloWorld/startup/serverGlobals.jsx
+++ b/client/app/bundles/HelloWorld/startup/serverGlobals.jsx
@@ -1,0 +1,3 @@
+import HelloWorldAppServer from './HelloWorldAppServer';
+
+global.HelloWorldApp = HelloWorldAppServer;

--- a/client/webpack.client.base.config.js
+++ b/client/webpack.client.base.config.js
@@ -20,7 +20,7 @@ module.exports = {
 
     // This will contain the app entry points defined by webpack.hot.config and webpack.rails.config
     app: [
-      './app/bundles/HelloWorld/startup/globals',
+      './app/bundles/HelloWorld/startup/clientGlobals',
     ],
   },
   resolve: {

--- a/client/webpack.server.rails.config.js
+++ b/client/webpack.server.rails.config.js
@@ -1,0 +1,37 @@
+// Wbpack configuration for server bundle
+
+const webpack = require('webpack');
+const path = require('path');
+
+module.exports = {
+
+  // the project dir
+  context: __dirname,
+  entry: ['./app/bundles/HelloWorld/startup/serverGlobals'],
+  output: {
+    filename: 'server-bundle.js',
+    path: '../app/assets/javascripts/generated',
+  },
+  resolve: {
+    extensions: ['', '.webpack.js', '.web.js', '.js', '.jsx', 'config.js'],
+    alias: {
+      lib: path.join(process.cwd(), 'app', 'lib'),
+    },
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
+      },
+    }),
+  ],
+  module: {
+    loaders: [
+      {test: /\.jsx?$/, loader: 'babel-loader', exclude: /node_modules/},
+
+      // React is necessary for the client rendering:
+      {test: require.resolve('react'), loader: 'expose?React'},
+      {test: require.resolve('react-dom/server'), loader: 'expose?ReactDOMServer'},
+    ],
+  },
+};

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,10 +11,10 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: 4409c3aa817e8c4d25777a2410472803f0390b8cbf5b741cdbab0d21bd2db19d347e6e3080cf892fe19922cd8e6c8096f76fd8963c3b5e65d25f3f0055693246
+  secret_key_base: b40125f9353dd35bddba2510991f8de0bf6817327132a6b43ac371f44086ffa652b03dee35717a30da2cc696df238f4c899ed03f72c90eda0b5b0ebbc27d72d7
 
 test:
-  secret_key_base: b1e6b048b34f4c4e585b18c6054349c4a7f16b9c8a4d5d761a40eac93c2ec587d93b58b8cb138d2fae30fd34f8c9326b1b48b782d7765c7e35d6f27cae427347
+  secret_key_base: 6c2ff1652d81211b68c1d55a470f8d143c58f5947bf258b6c820034b5c75aa63bafc387cf4000ebbaace3d2af648e295365391878f14c066e9b1573dad017f12
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
Comparison of running generator with alternate options:
- (base) `rails generate react_on_rails:install`
- (HEAD) `rails generate react_on_rails:install --server-rendering`
