### PR TITLE
basic to basic-heroku-deployment

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/heroku/heroku-buildpack-nodejs.git
+https://github.com/heroku/heroku-buildpack-ruby.git

--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,8 @@ group :development do
 end
 
 gem 'bootstrap-sass'
+
+# For Heroku deployment
+gem 'rails_12factor', group: :production
+gem 'puma', group: :production
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    puma (2.15.3)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -111,6 +112,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.4)
+    rails_stdout_logging (0.0.4)
     railties (4.2.4)
       actionpack (= 4.2.4)
       activesupport (= 4.2.4)
@@ -165,7 +171,9 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails
+  puma
   rails (= 4.2.4)
+  rails_12factor
   react_on_rails!
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,15 @@
+workers Integer(ENV["WEB_CONCURRENCY"] || 2)
+threads_count = Integer(ENV["MAX_THREADS"] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup DefaultRackup
+port ENV["PORT"] || 3000
+environment ENV["RACK_ENV"] || "development"
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,10 +11,10 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: 4409c3aa817e8c4d25777a2410472803f0390b8cbf5b741cdbab0d21bd2db19d347e6e3080cf892fe19922cd8e6c8096f76fd8963c3b5e65d25f3f0055693246
+  secret_key_base: 8c0bd919e3c0af21b472ba201131d52b62bc4aee8dec14ab275f36b3279a8de088d7b9f252128aa3c88a16f0d58bbe871a2bb9126cd18f3c15237ca70d2faf28
 
 test:
-  secret_key_base: b1e6b048b34f4c4e585b18c6054349c4a7f16b9c8a4d5d761a40eac93c2ec587d93b58b8cb138d2fae30fd34f8c9326b1b48b782d7765c7e35d6f27cae427347
+  secret_key_base: 5654263677a717375fa12900381541b3437ec09cf0d519c91420f6d482aecb26948031493b067e159f101ab9b6f3b5c59b993804c7a061a4ce4d62a54e93052f
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.


### PR DESCRIPTION
Comparison of running generator with alternate options:
- (base) `rails generate react_on_rails:install`
- (HEAD) `rails generate react_on_rails:install --heroku-deployment`
